### PR TITLE
PDB3 Revamp

### DIFF
--- a/pano/methods/dictfuncs.py
+++ b/pano/methods/dictfuncs.py
@@ -173,16 +173,15 @@ def dictstatus(node_dict, reports_dict, status_dict, sort=True, sortby=None, asc
                     # Append to the unreported list.
                     unreported_list = append_list(data, status_dict[node_name], unreported_list, report_status)
                 # If its got mismatching timestamps put it in the mismatching list
-                elif node_has_mismatching_timestamps is True:
+                if node_has_mismatching_timestamps is True:
                     mismatch_list = append_list(data, status_dict[node_name], mismatch_list, report_status)
                 # If the node is not unreported or has mismatching timestamps.. proceed to put in the correct lists.
-                else:
-                    if report_status == 'changed':
-                        changed_list = append_list(data, status_dict[node_name], changed_list, report_status)
-                    elif report_status == 'failed':
-                        failed_list = append_list(data, status_dict[node_name], failed_list, report_status)
-                    elif report_status == 'pending':
-                        pending_list = append_list(data, status_dict[node_name], pending_list, report_status)
+                if report_status == 'changed':
+                    changed_list = append_list(data, status_dict[node_name], changed_list, report_status)
+                elif report_status == 'failed':
+                    failed_list = append_list(data, status_dict[node_name], failed_list, report_status)
+                elif report_status == 'pending':
+                    pending_list = append_list(data, status_dict[node_name], pending_list, report_status)
 
     elif sortbycol <= 3 and get_status == 'all':
         for node_name, data in node_dict.items():

--- a/pano/views/api/dashboard_data.py
+++ b/pano/views/api/dashboard_data.py
@@ -64,7 +64,7 @@ def dashboard_status_json(request):
             'url': source_url,
             'certs': source_certs,
             'verify': source_verify,
-            'id': 'event-counts',
+            'id': 'event_counts',
             'path': 'event-counts',
             'api_version': 'v4',
             'params': events_params,
@@ -83,7 +83,7 @@ def dashboard_status_json(request):
     # Information about all active nodes in puppet
     all_nodes_list = puppetdb_results['all_nodes']
     # All available events for the latest puppet reports
-    event_list = puppetdb_results['event-counts']
+    event_list = puppetdb_results['event_counts']
 
     failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_list,
                                                                                          event_list,

--- a/pano/views/api/dashboard_data.py
+++ b/pano/views/api/dashboard_data.py
@@ -35,6 +35,12 @@ def dashboard_status_json(request):
             },
         'summarize_by': 'certname',
     }
+    reports_params = {
+        'query':
+            {
+                1: '["and",["=","latest_report?",true],["in", "certname",["extract", "certname",["select_nodes",["null?","deactivated",true]]]]]'
+            }
+    }
 
     jobs = {
         'tot_resource': {
@@ -60,6 +66,16 @@ def dashboard_status_json(request):
             'path': '/nodes',
             'request': request
         },
+        'reports': {
+            'url': source_url,
+            'certs': source_certs,
+            'verify': source_verify,
+            'api_version': 'v4',
+            'id': 'reports',
+            'path': '/reports',
+            'params': reports_params,
+            'request': request
+        },
         'events': {
             'url': source_url,
             'certs': source_certs,
@@ -82,11 +98,17 @@ def dashboard_status_json(request):
     avg_resource_node = puppetdb_results['avg_resource']
     # Information about all active nodes in puppet
     all_nodes_list = puppetdb_results['all_nodes']
+    all_nodes_dict = {item['certname']: item for item in all_nodes_list}
     # All available events for the latest puppet reports
     event_list = puppetdb_results['event_counts']
+    event_dict = {item['subject']['title']: item for item in event_list}
+    # All of the latest reports
+    reports_list = puppetdb_results['reports']
+    reports_dict = {item['certname']: item for item in reports_list}
 
-    failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_list,
-                                                                                         event_list,
+    failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_dict,
+                                                                                         reports_dict,
+                                                                                         event_dict,
                                                                                          sort=True,
                                                                                          sortby='latestReport',
                                                                                          get_status='notall',
@@ -147,6 +169,12 @@ def dashboard_nodes_json(request):
                 1: '["and",["=","latest_report?",true],["in", "certname",["extract", "certname",["select_nodes",["null?","deactivated",true]]]]]'
             },
     }
+    reports_params = {
+        'query':
+            {
+                1: '["and",["=","latest_report?",true],["in", "certname",["extract", "certname",["select_nodes",["null?","deactivated",true]]]]]'
+            }
+    }
     nodes_params = {
         'limit': 25,
         'order_by': {
@@ -172,7 +200,7 @@ def dashboard_nodes_json(request):
             'url': source_url,
             'certs': source_certs,
             'verify': source_verify,
-            'id': 'event-counts',
+            'id': 'event_counts',
             'path': 'event-counts',
             'api_version': 'v4',
             'params': events_params,
@@ -188,16 +216,35 @@ def dashboard_nodes_json(request):
             'params': nodes_params,
             'request': request
         },
+        'reports': {
+            'url': source_url,
+            'certs': source_certs,
+            'verify': source_verify,
+            'api_version': 'v4',
+            'id': 'reports',
+            'path': '/reports',
+            'params': reports_params,
+            'request': request
+        },
     }
 
     puppetdb_results = run_puppetdb_jobs(jobs)
     # Information about all active nodes in puppet
     all_nodes_list = puppetdb_results['all_nodes']
-    event_list = puppetdb_results['event-counts']
+    all_nodes_dict = {item['certname']: item for item in all_nodes_list}
+    # All available events for the latest puppet reports
+    event_list = puppetdb_results['event_counts']
+    event_dict = {item['subject']['title']: item for item in event_list}
+    # All of the latest reports
+    reports_list = puppetdb_results['reports']
+    reports_dict = {item['certname']: item for item in reports_list}
+    # 25 Nodes
     node_list = puppetdb_results['nodes']
+    node_dict = {item['certname']: item for item in node_list}
 
-    failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_list,
-                                                                                         event_list,
+    failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_dict,
+                                                                                         reports_dict,
+                                                                                         event_dict,
                                                                                          sort=True,
                                                                                          sortby='latestReport',
                                                                                          get_status='notall',
@@ -210,7 +257,7 @@ def dashboard_nodes_json(request):
 
     if dashboard_show == 'recent':
         merged_nodes_list = dictstatus(
-            node_list, event_list, sort=False, get_status="all", puppet_run_time=puppet_run_time)
+            node_dict, reports_dict, event_dict, sort=False, get_status="all", puppet_run_time=puppet_run_time)
     elif dashboard_show == 'failed':
         merged_nodes_list = failed_list
     elif dashboard_show == 'unreported':
@@ -223,7 +270,7 @@ def dashboard_nodes_json(request):
         merged_nodes_list = pending_list
     else:
         merged_nodes_list = dictstatus(
-            node_list, event_list, sort=False, get_status="all", puppet_run_time=puppet_run_time)
+            node_dict, reports_dict, event_dict, sort=False, get_status="all", puppet_run_time=puppet_run_time)
 
     context['node_list'] = merged_nodes_list
     context['selected_view'] = dashboard_show
@@ -253,6 +300,12 @@ def dashboard_json(request):
                 1: '["and",["=","latest_report?",true],["in", "certname",["extract", "certname",["select_nodes",["null?","deactivated",true]]]]]'
             },
         'summarize_by': 'certname',
+    }
+    reports_params = {
+        'query':
+            {
+                1: '["and",["=","latest_report?",true],["in", "certname",["extract", "certname",["select_nodes",["null?","deactivated",true]]]]]'
+            }
     }
     nodes_params = {
         'limit': 25,
@@ -293,10 +346,20 @@ def dashboard_json(request):
             'url': source_url,
             'certs': source_certs,
             'verify': source_verify,
-            'id': 'event-counts',
+            'id': 'event_counts',
             'path': '/event-counts',
             'api_version': 'v4',
             'params': events_params,
+            'request': request
+        },
+        'reports': {
+            'url': source_url,
+            'certs': source_certs,
+            'verify': source_verify,
+            'api_version': 'v4',
+            'id': 'reports',
+            'path': '/reports',
+            'params': reports_params,
             'request': request
         },
         'nodes': {
@@ -321,11 +384,20 @@ def dashboard_json(request):
     avg_resource_node = puppetdb_results['avg_resource']
     # Information about all active nodes in puppet
     all_nodes_list = puppetdb_results['all_nodes']
+    all_nodes_dict = {item['certname']: item for item in all_nodes_list}
     # All available events for the latest puppet reports
-    event_list = puppetdb_results['event-counts']
+    event_list = puppetdb_results['event_counts']
+    event_dict = {item['subject']['title']: item for item in event_list}
+    # All of the latest reports
+    reports_list = puppetdb_results['reports']
+    reports_dict = {item['certname']: item for item in reports_list}
+    # 25 Nodes
     node_list = puppetdb_results['nodes']
-    failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_list,
-                                                                                         event_list,
+    node_dict = {item['certname']: item for item in node_list}
+
+    failed_list, changed_list, unreported_list, mismatch_list, pending_list = dictstatus(all_nodes_dict,
+                                                                                         reports_dict,
+                                                                                         event_dict,
                                                                                          sort=True,
                                                                                          sortby='latestReport',
                                                                                          get_status='notall',
@@ -345,7 +417,7 @@ def dashboard_json(request):
 
     if dashboard_show == 'recent':
         merged_nodes_list = dictstatus(
-            node_list, event_list, sort=False, get_status="all", puppet_run_time=puppet_run_time)
+            node_dict, reports_dict, event_dict, sort=False, get_status="all", puppet_run_time=puppet_run_time)
     elif dashboard_show == 'failed':
         merged_nodes_list = failed_list
     elif dashboard_show == 'unreported':
@@ -358,7 +430,7 @@ def dashboard_json(request):
         merged_nodes_list = pending_list
     else:
         merged_nodes_list = dictstatus(
-            node_list, event_list, sort=False, get_status="all", puppet_run_time=puppet_run_time)
+            node_dict, reports_dict, event_dict, sort=False, get_status="all", puppet_run_time=puppet_run_time)
 
     context['node_list'] = merged_nodes_list
     context['selected_view'] = dashboard_show

--- a/pano/views/api/fact_data.py
+++ b/pano/views/api/fact_data.py
@@ -56,7 +56,7 @@ def facts_json(request):
                 },
             'order-by':
                 {
-                    'order-field':
+                    'order_field':
                         {
                             'field': 'name',
                             'order': 'asc',
@@ -69,7 +69,7 @@ def facts_json(request):
                 {
                     1: '["=","certname","' + certname + '"]'
                 },
-            'order-by':
+            'order_by':
                 {
                     'order-field':
                         {
@@ -82,7 +82,7 @@ def facts_json(request):
         api_url=source_url,
         cert=source_certs,
         verify=source_verify,
-        path='/facts/',
+        path='facts',
         params=puppetdb.mk_puppetdb_query(
             facts_params, request),
     )

--- a/pano/views/node_facts.py
+++ b/pano/views/node_facts.py
@@ -33,7 +33,7 @@ def facts(request, certname=None):
         api_url=source_url,
         cert=source_certs,
         verify=source_verify,
-        path='/facts/',
+        path='facts',
         params=puppetdb.mk_puppetdb_query(
             facts_params, request),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django==1.7.6
+Django
 django-auth-ldap==1.2.5
 git+https://github.com/rbarrois/python-ldap.git@py3
-pytz==2014.10
-requests==2.5.1
+pytz
+requests
 pyyaml

--- a/tests/test_dictfuncs.py
+++ b/tests/test_dictfuncs.py
@@ -53,126 +53,171 @@ class MergeNodeEventData(TestCase):
             },
         }
 
-        nodes_data = [
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['failed-node']['catalog'],
+        nodes_data = {
+            'failed-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['failed-node']['catalog'],
                 'certname': 'failed-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['failed-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['failed-node']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['failed-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['failed-node']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['missmatch-node1']['catalog'],
+            'missmatch-node1.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['missmatch-node1']['catalog'],
                 'certname': 'missmatch-node1.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['missmatch-node1']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['missmatch-node1']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['missmatch-node1']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['missmatch-node1']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['missmatch-node2']['catalog'],
+            'missmatch-node2.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['missmatch-node2']['catalog'],
                 'certname': 'missmatch-node2.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['missmatch-node2']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['missmatch-node2']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['missmatch-node2']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['missmatch-node2']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['missmatch-node3']['catalog'],
+            'missmatch-node3.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['missmatch-node3']['catalog'],
                 'certname': 'missmatch-node3.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['missmatch-node3']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['missmatch-node3']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['missmatch-node3']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['missmatch-node3']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['unreported-node']['catalog'],
+            'unreported-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['unreported-node']['catalog'],
                 'certname': 'unreported-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['unreported-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['unreported-node']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['unreported-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['unreported-node']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['changed-node']['catalog'],
+            'changed-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['changed-node']['catalog'],
                 'certname': 'changed-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['changed-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['changed-node']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['changed-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['changed-node']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['unchanged-node']['catalog'],
+            'unchanged-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['unchanged-node']['catalog'],
                 'certname': 'unchanged-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['unchanged-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['unchanged-node']['report'],
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['unchanged-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['unchanged-node']['report'],
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['pending-node']['catalog'],
+            'pending-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['pending-node']['catalog'],
                 'certname': 'pending-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['pending-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['pending-node']['report'],
-            }]
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['pending-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['pending-node']['report'],
+            }}
 
-        events_data = [{'failures': 0,
-                        'noops': 0,
-                        'skips': 0,
-                        'subject': {'title': 'changed-node.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 78},
-                       {'failures': 0,
-                        'noops': 100,
-                        'skips': 0,
-                        'subject': {'title': 'pending-node.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 0},
-                       {'failures': 20,
-                        'noops': 0,
-                        'skips': 10,
-                        'subject': {'title': 'failed-node.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 5},
-                       {'failures': 20,
-                        'noops': 0,
-                        'skips': 10,
-                        'subject': {'title': 'missmatch-node1.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 5},
-                       {'failures': 0,
-                        'noops': 0,
-                        'skips': 0,
-                        'subject': {'title': 'missmatch-node2.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 25},
-                       {'failures': 0,
-                        'noops': 50,
-                        'skips': 0,
-                        'subject': {'title': 'missmatch-node3.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 0}
-                       ]
+        events_data = {
+            'changed-node.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'changed-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 78
+            },
+            'pending-node.example.com': {
+                'failures': 0,
+                'noops': 100,
+                'skips': 0,
+                'subject': {'title': 'pending-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            },
+            'unreported-node.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'unreported-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            },
+            'failed-node.example.com': {
+                'failures': 20,
+                'noops': 0,
+                'skips': 10,
+                'subject': {'title': 'failed-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 5
+            },
+            'missmatch-node1.example.com': {
+                'failures': 20,
+                'noops': 0,
+                'skips': 10,
+                'subject': {'title': 'missmatch-node1.example.com'},
+                'subject-type': 'certname',
+                'successes': 5
+            },
+            'missmatch-node2.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'missmatch-node2.example.com'},
+                'subject-type': 'certname',
+                'successes': 25
+            },
+            'missmatch-node3.example.com': {
+                'failures': 0,
+                'noops': 50,
+                'skips': 0,
+                'subject': {'title': 'missmatch-node3.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            }
+        }
+        reports_data = {
+            'changed-node.example.com': {
+                'status': 'changed',
+            },
+            'pending-node.example.com': {
+                'status': 'unchanged',
+            },
+            'failed-node.example.com': {
+                'status': 'failed',
+            },
+            'unreported-node.example.com': {
+                'status': 'unchanged',
+            },
+            'missmatch-node1.example.com': {
+                'status': 'failed',
+            },
+            'missmatch-node2.example.com': {
+                'status': 'changed',
+            },
+            'missmatch-node3.example.com': {
+                'status': 'unchanged',
+            }
+        }
         failed_list, changed_list, unreported_list, missmatch_list, pending_list = dictstatus(nodes_data,
+                                                                                              reports_data,
                                                                                               events_data,
                                                                                               sort=False,
                                                                                               get_status='notall')
@@ -188,7 +233,7 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['failed-node']['facts'])),
                 'Y-m-d H:i:s'),
-            5, 0, 20, 10), (
+            5, 0, 20, 10, 'failed'), (
             'missmatch-node1.example.com',
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['catalog'])),
@@ -199,75 +244,36 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['facts'])),
                 'Y-m-d H:i:s'),
-            5, 0, 20, 10)]
+            5, 0, 20, 10, 'failed')]
 
-        changed_expected = [(
-            'failed-node.example.com',
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['failed-node']['catalog'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['failed-node']['report'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['failed-node']['facts'])),
-                'Y-m-d H:i:s'),
-            5, 0, 20, 10), (
-            'missmatch-node1.example.com',
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['catalog'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['report'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['facts'])),
-                'Y-m-d H:i:s'),
-            5, 0, 20, 10), (
-            'missmatch-node2.example.com',
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['catalog'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['report'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['facts'])),
-                'Y-m-d H:i:s'),
-            25, 0, 0, 0), (
-            'missmatch-node3.example.com',
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['catalog'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['report'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['facts'])),
-                'Y-m-d H:i:s'),
-            0, 50, 0, 0), (
-            'changed-node.example.com',
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['changed-node']['catalog'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['changed-node']['report'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['changed-node']['facts'])),
-                'Y-m-d H:i:s'),
-            78, 0, 0, 0), (
-            'pending-node.example.com',
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['pending-node']['catalog'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['pending-node']['report'])),
-                'Y-m-d H:i:s'),
-            filters.date(
-                localtime(json_to_datetime(nodes_timestamps['pending-node']['facts'])),
-                'Y-m-d H:i:s'),
-            0, 100, 0, 0)]
+        changed_expected = [
+            (
+                'missmatch-node2.example.com',
+                filters.date(
+                    localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['catalog'])),
+                    'Y-m-d H:i:s'),
+                filters.date(
+                    localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['report'])),
+                    'Y-m-d H:i:s'),
+                filters.date(
+                    localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['facts'])),
+                    'Y-m-d H:i:s'),
+                25, 0, 0, 0, 'changed'
+            ),
+            (
+                'changed-node.example.com',
+                filters.date(
+                    localtime(json_to_datetime(nodes_timestamps['changed-node']['catalog'])),
+                    'Y-m-d H:i:s'),
+                filters.date(
+                    localtime(json_to_datetime(nodes_timestamps['changed-node']['report'])),
+                    'Y-m-d H:i:s'),
+                filters.date(
+                    localtime(json_to_datetime(nodes_timestamps['changed-node']['facts'])),
+                    'Y-m-d H:i:s'),
+                78, 0, 0, 0, 'changed'
+            ),
+        ]
 
         unreported_expected = [(
             'unreported-node.example.com',
@@ -280,7 +286,7 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['unreported-node']['facts'])),
                 'Y-m-d H:i:s'),
-            0, 0, 0, 0)]
+            0, 0, 0, 0, 'unchanged')]
 
         missmatch_expected = [(
             'missmatch-node1.example.com',
@@ -293,7 +299,7 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['facts'])),
                 'Y-m-d H:i:s'),
-            5, 0, 20, 10), (
+            5, 0, 20, 10, 'failed'), (
             'missmatch-node2.example.com',
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['catalog'])),
@@ -304,7 +310,7 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['facts'])),
                 'Y-m-d H:i:s'),
-            25, 0, 0, 0), (
+            25, 0, 0, 0, 'changed'), (
             'missmatch-node3.example.com',
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['catalog'])),
@@ -315,7 +321,7 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['facts'])),
                 'Y-m-d H:i:s'),
-            0, 50, 0, 0)]
+            0, 50, 0, 0, 'pending')]
 
         pending_expected = [(
             'missmatch-node3.example.com',
@@ -328,7 +334,7 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['facts'])),
                 'Y-m-d H:i:s'),
-            0, 50, 0, 0), (
+            0, 50, 0, 0, 'pending'), (
             'pending-node.example.com',
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['pending-node']['catalog'])),
@@ -339,8 +345,18 @@ class MergeNodeEventData(TestCase):
             filters.date(
                 localtime(json_to_datetime(nodes_timestamps['pending-node']['facts'])),
                 'Y-m-d H:i:s'),
-            0, 100, 0, 0)]
-        # failed_list, changed_list, unreported_list, mismatch_list, pending_list
+            0, 100, 0, 0, 'pending')]
+        # Sort lists so its easier to verify...
+        failed_list.sort(key=lambda tup: tup[0])
+        failed_expected.sort(key=lambda tup: tup[0])
+        changed_list.sort(key=lambda tup: tup[0])
+        changed_expected.sort(key=lambda tup: tup[0])
+        unreported_list.sort(key=lambda tup: tup[0])
+        unreported_expected.sort(key=lambda tup: tup[0])
+        missmatch_list.sort(key=lambda tup: tup[0])
+        missmatch_expected.sort(key=lambda tup: tup[0])
+        pending_list.sort(key=lambda tup: tup[0])
+        pending_expected.sort(key=lambda tup: tup[0])
         if failed_list != failed_expected:
             self.fail(msg='Failed list does not match expectations.')
         if changed_list != changed_expected:
@@ -397,193 +413,271 @@ class MergeNodeEventData(TestCase):
             },
         }
 
-        nodes_data = [
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['failed-node']['catalog'],
+        nodes_data = {
+            'failed-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['failed-node']['catalog'],
                 'certname': 'failed-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['failed-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['failed-node']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['failed-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['failed-node']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['missmatch-node1']['catalog'],
+            'missmatch-node1.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['missmatch-node1']['catalog'],
                 'certname': 'missmatch-node1.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['missmatch-node1']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['missmatch-node1']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['missmatch-node1']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['missmatch-node1']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['missmatch-node2']['catalog'],
+            'missmatch-node2.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['missmatch-node2']['catalog'],
                 'certname': 'missmatch-node2.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['missmatch-node2']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['missmatch-node2']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['missmatch-node2']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['missmatch-node2']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['missmatch-node3']['catalog'],
+            'missmatch-node3.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['missmatch-node3']['catalog'],
                 'certname': 'missmatch-node3.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['missmatch-node3']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['missmatch-node3']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['missmatch-node3']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['missmatch-node3']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['unreported-node']['catalog'],
+            'unreported-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['unreported-node']['catalog'],
                 'certname': 'unreported-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['unreported-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['unreported-node']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['unreported-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['unreported-node']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['changed-node']['catalog'],
+            'changed-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['changed-node']['catalog'],
                 'certname': 'changed-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['changed-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['changed-node']['report']
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['changed-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['changed-node']['report']
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['unchanged-node']['catalog'],
+            'unchanged-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['unchanged-node']['catalog'],
                 'certname': 'unchanged-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['unchanged-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['unchanged-node']['report'],
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['unchanged-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['unchanged-node']['report'],
             },
-            {
-                'catalog-environment': 'production',
-                'catalog-timestamp': nodes_timestamps['pending-node']['catalog'],
+            'pending-node.example.com': {
+                'catalog_environment': 'production',
+                'catalog_timestamp': nodes_timestamps['pending-node']['catalog'],
                 'certname': 'pending-node.example.com',
                 'deactivated': None,
-                'facts-environment': 'production',
-                'facts-timestamp': nodes_timestamps['pending-node']['facts'],
-                'report-environment': 'production',
-                'report-timestamp': nodes_timestamps['pending-node']['report'],
-            }]
+                'facts_environment': 'production',
+                'facts_timestamp': nodes_timestamps['pending-node']['facts'],
+                'report_environment': 'production',
+                'report_timestamp': nodes_timestamps['pending-node']['report'],
+            }
+        }
 
-        events_data = [{'failures': 0,
-                        'noops': 0,
-                        'skips': 0,
-                        'subject': {'title': 'changed-node.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 78},
-                       {'failures': 0,
-                        'noops': 100,
-                        'skips': 0,
-                        'subject': {'title': 'pending-node.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 0},
-                       {'failures': 20,
-                        'noops': 0,
-                        'skips': 10,
-                        'subject': {'title': 'failed-node.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 5},
-                       {'failures': 20,
-                        'noops': 0,
-                        'skips': 10,
-                        'subject': {'title': 'missmatch-node1.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 5},
-                       {'failures': 0,
-                        'noops': 0,
-                        'skips': 0,
-                        'subject': {'title': 'missmatch-node2.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 25},
-                       {'failures': 0,
-                        'noops': 50,
-                        'skips': 0,
-                        'subject': {'title': 'missmatch-node3.example.com'},
-                        'subject-type': 'certname',
-                        'successes': 0}
-                       ]
+        events_data = {
+            'changed-node.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'changed-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 78
+            },
+            'pending-node.example.com': {
+                'failures': 0,
+                'noops': 100,
+                'skips': 0,
+                'subject': {'title': 'pending-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            },
+            'failed-node.example.com': {
+                'failures': 20,
+                'noops': 0,
+                'skips': 10,
+                'subject': {'title': 'failed-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 5
+            },
+            'unreported-node.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'unreported-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            },
+            'unchanged-node.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'unchanged-node.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            },
+            'missmatch-node1.example.com': {
+                'failures': 20,
+                'noops': 0,
+                'skips': 10,
+                'subject': {'title': 'missmatch-node1.example.com'},
+                'subject-type': 'certname',
+                'successes': 5
+            },
+            'missmatch-node2.example.com': {
+                'failures': 0,
+                'noops': 0,
+                'skips': 0,
+                'subject': {'title': 'missmatch-node2.example.com'},
+                'subject-type': 'certname',
+                'successes': 25
+            },
+            'missmatch-node3.example.com': {
+                'failures': 0,
+                'noops': 50,
+                'skips': 0,
+                'subject': {'title': 'missmatch-node3.example.com'},
+                'subject-type': 'certname',
+                'successes': 0
+            }
+        }
+
+        reports_data = {
+            'changed-node.example.com': {
+                'status': 'changed',
+            },
+            'pending-node.example.com': {
+                'status': 'pending',
+            },
+            'failed-node.example.com': {
+                'status': 'failed',
+            },
+            'missmatch-node1.example.com': {
+                'status': 'failed',
+            },
+            'missmatch-node2.example.com': {
+                'status': 'changed',
+            },
+            'missmatch-node3.example.com': {
+                'status': 'pending',
+            },
+            'unreported-node.example.com': {
+                'status': 'unchanged',
+            },
+            'unchanged-node.example.com': {
+                'status': 'unchanged',
+            }
+        }
+
         merged_list = dictstatus(nodes_data,
+                                 reports_data,
                                  events_data,
                                  sort=False,
                                  get_status='all')
         # ('certname', 'latestCatalog', 'latestReport', 'latestFacts', 'success', 'noop', 'failure', 'skipped')
-        merged_expected = [('failed-node.example.com',
-                            filters.date(localtime(json_to_datetime(nodes_timestamps['failed-node']['catalog'])),
-                                         'Y-m-d H:i:s'),
-                            filters.date(localtime(json_to_datetime(nodes_timestamps['failed-node']['report'])),
-                                         'Y-m-d H:i:s'),
-                            filters.date(localtime(json_to_datetime(nodes_timestamps['failed-node']['facts'])),
-                                         'Y-m-d H:i:s'),
-                            5, 0, 20, 10), (
-                               'missmatch-node1.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['facts'])),
-                                            'Y-m-d H:i:s'),
-                               5, 0, 20, 10), (
-                               'missmatch-node2.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['facts'])),
-                                            'Y-m-d H:i:s'),
-                               25, 0, 0, 0), (
-                               'missmatch-node3.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['facts'])),
-                                            'Y-m-d H:i:s'),
-                               0, 50, 0, 0), (
-                               'unreported-node.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['unreported-node']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['unreported-node']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['unreported-node']['facts'])),
-                                            'Y-m-d H:i:s'),
-                               0, 0, 0, 0), (
-                               'changed-node.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['changed-node']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['changed-node']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['changed-node']['facts'])),
-                                            'Y-m-d H:i:s'),
-                               78, 0, 0, 0), (
-                               'unchanged-node.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['unchanged-node']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['unchanged-node']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['unchanged-node']['facts'])),
-                                            'Y-m-d H:i:s'),
-                               0, 0, 0, 0), (
-                               'pending-node.example.com',
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['pending-node']['catalog'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['pending-node']['report'])),
-                                            'Y-m-d H:i:s'),
-                               filters.date(localtime(json_to_datetime(nodes_timestamps['pending-node']['facts'])),
-                                            'Y-m-d H:i:s'),
-                           0, 100, 0, 0)]
+        merged_expected = [
+            (
+                'failed-node.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['failed-node']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['failed-node']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['failed-node']['facts'])),
+                             'Y-m-d H:i:s'),
+                5, 0, 20, 10, 'failed'
+            ),
+            (
+                'missmatch-node1.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node1']['facts'])),
+                             'Y-m-d H:i:s'),
+                5, 0, 20, 10, 'failed'
+            ),
+            (
+                'missmatch-node2.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node2']['facts'])),
+                             'Y-m-d H:i:s'),
+                25, 0, 0, 0, 'changed'
+            ),
+            (
+                'missmatch-node3.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['missmatch-node3']['facts'])),
+                             'Y-m-d H:i:s'),
+                0, 50, 0, 0, 'pending'
+            ),
+            (
+                'unreported-node.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['unreported-node']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['unreported-node']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['unreported-node']['facts'])),
+                             'Y-m-d H:i:s'),
+                0, 0, 0, 0, 'unchanged'
+            ),
+            (
+                'changed-node.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['changed-node']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['changed-node']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['changed-node']['facts'])),
+                             'Y-m-d H:i:s'),
+                78, 0, 0, 0, 'changed'
+            ),
+            (
+                'unchanged-node.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['unchanged-node']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['unchanged-node']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['unchanged-node']['facts'])),
+                             'Y-m-d H:i:s'),
+                0, 0, 0, 0, 'unchanged'
+            ),
+            (
+                'pending-node.example.com',
+                filters.date(localtime(json_to_datetime(nodes_timestamps['pending-node']['catalog'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['pending-node']['report'])),
+                             'Y-m-d H:i:s'),
+                filters.date(localtime(json_to_datetime(nodes_timestamps['pending-node']['facts'])),
+                             'Y-m-d H:i:s'),
+                0, 100, 0, 0, 'pending'
+            )]
         # failed_list, changed_list, unreported_list, mismatch_list, pending_list
+        merged_list.sort(key=lambda tup: tup[0])
+        merged_expected.sort(key=lambda tup: tup[0])
         self.assertEqual(merged_list, merged_expected)

--- a/tests/test_puppetdb_functions.py
+++ b/tests/test_puppetdb_functions.py
@@ -24,11 +24,11 @@ class CreatePuppetdbQueries(TestCase):
                 {
                     'operator': 'and',
                     1: '["=","hash","e4fug294hf3293hf9348g3804hg3084h"]',
-                    2: '["=","latest-report?",true]'
+                    2: '["=","latest_report?",true]'
                 },
         }
         expected_results = {
-            'query': '["and",["=","hash","e4fug294hf3293hf9348g3804hg3084h"],["=","latest-report?",true]]'
+            'query': '["and",["=","hash","e4fug294hf3293hf9348g3804hg3084h"],["=","latest_report?",true]]'
         }
         results = mk_puppetdb_query(content)
         self.assertEqual(expected_results, results)
@@ -49,10 +49,10 @@ class CreatePuppetdbQueries(TestCase):
 
     def test_summarize_by_query(self):
         content = {
-            'summarize-by': 'containing-class',
+            'summarize_by': 'containing_class',
         }
         expected_results = {
-            'summarize-by': 'containing-class'
+            'summarize_by': 'containing_class'
         }
         results = mk_puppetdb_query(content)
         self.assertEqual(expected_results, results)
@@ -63,20 +63,20 @@ class CreatePuppetdbQueries(TestCase):
                 {
                     1: '["=","certname","hostname.example.com"]'
                 },
-            'summarize-by': 'containing-class',
+            'summarize_by': 'containing_class',
         }
         expected_results = {
             'query': '["and",["=","certname","hostname.example.com"]]',
-            'summarize-by': 'containing-class'
+            'summarize_by': 'containing_class'
         }
         results = mk_puppetdb_query(content)
         self.assertEqual(expected_results, results)
 
     def test_order_by_query(self):
         content = {
-            'order-by':
+            'order_by':
                 {
-                    'order-field':
+                    'order_field':
                         {
                             'field': 'report_timestamp',
                             'order': 'desc',
@@ -84,7 +84,7 @@ class CreatePuppetdbQueries(TestCase):
                 }
         }
         expected_results = {
-            'order-by': '[{"field":"report_timestamp","order":"desc"}]'
+            'order_by': '[{"field":"report_timestamp","order":"desc"}]'
         }
         results = mk_puppetdb_query(content)
         self.assertEqual(expected_results, results)
@@ -95,9 +95,9 @@ class CreatePuppetdbQueries(TestCase):
                 {
                     1: '["=","certname","hostname.example.com"]'
                 },
-            'order-by':
+            'order_by':
                 {
-                    'order-field':
+                    'order_field':
                         {
                             'field': 'report_timestamp',
                             'order': 'desc',
@@ -105,7 +105,7 @@ class CreatePuppetdbQueries(TestCase):
                 }
         }
         expected_results = {
-            'order-by': '[{"field":"report_timestamp","order":"desc"}]',
+            'order_by': '[{"field":"report_timestamp","order":"desc"}]',
             'query': '["and",["=","certname","hostname.example.com"]]'
         }
         results = mk_puppetdb_query(content)
@@ -119,9 +119,9 @@ class CreatePuppetdbQueries(TestCase):
                     1: '["=","certname","hostname1.example.com"]',
                     2: '["=","certname","hostname2.example.com"]'
                 },
-            'order-by':
+            'order_by':
                 {
-                    'order-field':
+                    'order_field':
                         {
                             'field': 'report_timestamp',
                             'order': 'desc',
@@ -130,7 +130,7 @@ class CreatePuppetdbQueries(TestCase):
         }
         expected_results = {
             'query': '["and",["=","certname","hostname1.example.com"],["=","certname","hostname2.example.com"]]',
-            'order-by': '[{"field":"report_timestamp","order":"desc"}]'
+            'order_by': '[{"field":"report_timestamp","order":"desc"}]'
         }
         results = mk_puppetdb_query(content)
         self.assertEqual(expected_results, results)


### PR DESCRIPTION
Uses the PuppetDB 3.0 information like report status to identify all the different statuses available.
Before this commit there was a lot of code in place to work out what was  failed, pending, changed, unchanged, possible compile errors etc.

The facts pages works again.