### PR TITLE
Fix bug with large divs if no events are present

### DIFF
--- a/pano/templates/pano/analytics/analytics.html
+++ b/pano/templates/pano/analytics/analytics.html
@@ -38,6 +38,9 @@
             <div class="panel panel-default">
                 <div class="panel-heading">Class Events</div>
                 <div class="panel-body">
+                    {% if not class_events %}
+                        <p class="alert alert-info">No class events to show</p>
+                    {% endif %}
                     <div id="class_events"></div>
                 </div>
             </div>
@@ -46,6 +49,9 @@
             <div class="panel panel-default">
                 <div class="panel-heading">Resource Events</div>
                 <div class="panel-body">
+                    {% if not resource_events %}
+                        <p class="alert alert-info">No resource events to show</p>
+                    {% endif %}
                     <div id="resource_events"></div>
                 </div>
             </div>
@@ -54,80 +60,92 @@
             <div class="panel panel-default">
                 <div class="panel-heading">Status Events</div>
                 <div class="panel-body">
+                    {% if not class_status %}
+                        <div class="alert alert-info">
+                            No status events to show
+                        </div>
+                    {% endif %}
                     <div id="status_events"></div>
                 </div>
             </div>
         </div>
     </div>
-    <script id="js_class">
-        var chart_classes = c3.generate({
-            bindto: '#class_events',
-            data: {
-                columns: [
-                    {% for event in class_events %}
-                        ['{{ event.0 }}', {{ event.1 }}],
-                    {% endfor %}
-                ],
-                type: 'pie',
-                onmouseover: function (d, i) {
-                    console.log("onmouseover", d, i);
+    {% if class_events %}
+        <script id="js_class">
+            var chart_classes = c3.generate({
+                bindto: '#class_events',
+                data: {
+                    columns: [
+                        {% for event in class_events %}
+                            ['{{ event.0 }}', {{ event.1 }}],
+                        {% endfor %}
+                    ],
+                    type: 'pie',
+                    onmouseover: function (d, i) {
+                        console.log("onmouseover", d, i);
+                    },
+                    onmouseout: function (d, i) {
+                        console.log("onmouseout", d, i);
+                    }
                 },
-                onmouseout: function (d, i) {
-                    console.log("onmouseout", d, i);
+                legend: {
+                    position: 'bottom',
+                    hide: true
                 }
-            },
-            legend: {
-                position: 'bottom',
-                hide: true
-            }
-        });
-    </script>
-    <script id="js_resource">
-        var chart_resources = c3.generate({
-            bindto: '#resource_events',
-            data: {
-                // iris data from R
-                columns: [
-                    {% for event in resource_events %}
-                        ['{{ event.0 }}', {{ event.1 }}],
-                    {% endfor %}
-                ],
-                type: 'pie',
-                onmouseover: function (d, i) {
-                    console.log("onmouseover", d, i);
+            });
+
+        </script>
+    {% endif %}
+    {% if resource_events %}
+        <script id="js_resource">
+            var chart_resources = c3.generate({
+                bindto: '#resource_events',
+                data: {
+                    // iris data from R
+                    columns: [
+                        {% for event in resource_events %}
+                            ['{{ event.0 }}', {{ event.1 }}],
+                        {% endfor %}
+                    ],
+                    type: 'pie',
+                    onmouseover: function (d, i) {
+                        console.log("onmouseover", d, i);
+                    },
+                    onmouseout: function (d, i) {
+                        console.log("onmouseout", d, i);
+                    }
                 },
-                onmouseout: function (d, i) {
-                    console.log("onmouseout", d, i);
+                legend: {
+                    position: 'bottom',
+                    hide: true
                 }
-            },
-            legend: {
-                position: 'bottom',
-                hide: true
-            }
-        });
-    </script>
-    <script id="js_status">
-        var chart_status = c3.generate({
-            bindto: '#status_events',
-            data: {
-                columns: [
-                    {% for status in class_status %}
-                        ['{{ status.0 }}', {{ status.1 }}],
-                    {% endfor %}
-                ],
-                type: 'pie',
-                onmouseover: function (d, i) {
-                    console.log("onmouseover", d, i);
+            });
+        </script>
+    {% endif %}
+    {% if class_status %}
+        <script id="js_status">
+            var chart_status = c3.generate({
+                bindto: '#status_events',
+                data: {
+                    columns: [
+                        {% for status in class_status %}
+                            ['{{ status.0 }}', {{ status.1 }}],
+                        {% endfor %}
+                    ],
+                    type: 'pie',
+                    onmouseover: function (d, i) {
+                        console.log("onmouseover", d, i);
+                    },
+                    onmouseout: function (d, i) {
+                        console.log("onmouseout", d, i);
+                    }
                 },
-                onmouseout: function (d, i) {
-                    console.log("onmouseout", d, i);
+                legend: {
+                    position: 'bottom'
                 }
-            },
-            legend: {
-                position: 'bottom'
-            }
-        });
-    </script>
+            });
+        </script>
+    {% endif %}
     <script id="js_avg_run_time">
         var chart_run_times = c3.generate({
             bindto: '#run_times',


### PR DESCRIPTION
If there are no events available to generate graphs with
on the analytics page a large div will only be shown.
This commit fixes it and provides a message so the
user knows that there are no events available.