### PR TITLE
Remove py3 branch requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 arrow
 Django
 django-auth-ldap==1.2.5
-git+https://github.com/rbarrois/python-ldap.git@py3
+git+https://github.com/rbarrois/python-ldap.git
 pytz
 pyyaml
 requests


### PR DESCRIPTION
py3 branch has been merged into master branch by
the module maintainer