### PR TITLE
Update requirements.txt django-auth-ldap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.7.6
-django-auth-ldap==1.2.5
+django-auth-ldap==1.2.7
 git+https://github.com/rbarrois/python-ldap.git@py3
 pytz==2014.10
 requests==2.5.1


### PR DESCRIPTION
django-auth-ldap==1.2.5 doesn't compile with python3  (SC rh-python34).
django-auth-ldap==1.2.7 does work.

Error message;
Running setup.py (path:/srv/.virtualenvs/panopuppet/build/python-ldap/setup.py) egg_info for package python-ldap
  Traceback (most recent call last):
    File "<string>", line 17, in <module>
    File "/srv/.virtualenvs/panopuppet/build/python-ldap/setup.py", line 53
      print name + ': ' + cfg.get('_ldap', name)
               ^
  SyntaxError: invalid syntax