### PR TITLE
CentOS 7 remove easy_install pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,6 @@ $ sudo yum install https://www.softwarecollections.org/en/scls/rhscl/httpd24/epe
 2) Install rh-python34 and the dependencies for the python-ldap module.
 ```
 $ sudo yum install rh-python34 libyaml-devel openldap-devel cyrus-sasl-devel gcc make
-$ sudo scl enable rh-python34 'easy_install pip'
 ```
 
 3) Install httpd24.


### PR DESCRIPTION
CentOS 7; rh-python34 already installs by rpm rh-python34-python-pip-1.5.6-4.el7.centos.noarch, easy_install pip not needed.