### PR TITLE
Fix bug with dashboard initial click

### DIFF
--- a/pano/static/pano/js/custom.js.min.js
+++ b/pano/static/pano/js/custom.js.min.js
@@ -37,3 +37,16 @@ $(function() {
         element.addClass('active');
     }
 });
+
+
+//http://www.jquerybyexample.net/2012/06/get-url-parameters-using-jquery.html
+function GetURLParameter(sParam) {
+    var sPageURL = window.location.search.substring(1);
+    var sURLVariables = sPageURL.split('&');
+    for (var i = 0; i < sURLVariables.length; i++) {
+        var sParameterName = sURLVariables[i].split('=');
+        if (sParameterName[0] == sParam) {
+            return sParameterName[1];
+        }
+    }
+}

--- a/pano/templates/pano/dashboard.html
+++ b/pano/templates/pano/dashboard.html
@@ -10,6 +10,7 @@
     <script src="{% static 'pano/tablesorter/jquery.tablesorter.min.js' %}"></script>
     <script src="{% static 'pano/tablesorter/jquery.tablesorter.widgets.min.js' %}"></script>
     <script src="{% static 'pano/js/bootbox.min.js' %}"></script>
+    <script src="{% static 'pano/js/custom.js.min.js' %}"></script>
     <script>
         $(document).ready(function () {
             get_data();
@@ -57,9 +58,12 @@
     <script>
         function get_data() {
             var backgroundTask = $.Deferred();
-            var url = '../api/dashboard/';
-            var recent = $('#recent');
-            $(recent).addClass("active").prependTo($(recent).parent()).siblings().removeClass("active");
+            var url = '../api/dashboard/?show=recent';
+            var show_type = $('#' + GetURLParameter('show'));
+            if (typeof GetURLParameter('show') != 'undefined') {
+                url = url + show_type.attr('href');
+            }
+            $(show_type).addClass("active").prependTo($(show_type).parent()).siblings().removeClass("active");
             $.get(url, function (json) {
                         var response = $(jQuery(json));
                         var nodes = response[0]['node_list'];


### PR DESCRIPTION
When you begin on a page that is not one of the dashboard tabs
and you click on for example any status, recent will always be shown
the first time. It is not until the second click that it will switch to that status.

This is a fix for that problem.