### PR TITLE
Fix bug with initial dashboard url

### DIFF
--- a/pano/templates/pano/dashboard.html
+++ b/pano/templates/pano/dashboard.html
@@ -58,8 +58,12 @@
         function get_data() {
             var backgroundTask = $.Deferred();
             var url = '../api/dashboard/';
-            var recent = $('#recent');
-            $(recent).addClass("active").prependTo($(recent).parent()).siblings().removeClass("active");
+            var show_type = $('#' + GetURLParameter('show'));
+            if (typeof GetURLParameter('show') != 'undefined') {
+                url = url + show_type.attr('href');
+            }
+            $(show_type).addClass("active").prependTo($(show_type).parent()).siblings().removeClass("active");
+
             $.get(url, function (json) {
                         var response = $(jQuery(json));
                         var nodes = response[0]['node_list'];


### PR DESCRIPTION
Bug where if a status that was not recent
was chosen while on another page that was
not the dashboard, you would be served the
recent data regardless.