### PR TITLE
Allow for custom ldap search filter

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -52,6 +52,8 @@ AUTH_METHOD: 'basic'
 LDAP_SERVER: 'ldap://ldap.forumsys.com'
 LDAP_BIND_DN: 'cn=read-only-admin,dc=example,dc=com'
 LDAP_BIND_PW: 'password'
+# Active directory filter
+# LDAP_FILTER: '(&(objectclass=User)(sAMAccountName=%(user)s))'
 LDAP_USEARCH_PATH: 'dc=example,dc=com'
 LDAP_GSEARCH_PATH:
 LDAP_ALLOW_GRP:

--- a/panopuppet/puppet/settings.py
+++ b/panopuppet/puppet/settings.py
@@ -98,8 +98,9 @@ if AUTH_METHOD == 'ldap':
     AUTH_LDAP_SERVER_URI = LDAP_SERVER
     AUTH_LDAP_BIND_DN = LDAP_BIND_DN
     AUTH_LDAP_BIND_PASSWORD = LDAP_BIND_PW
+    LDAP_SEARCH_FILTER = cfg.get('LDAP_FILTER', "(&(objectClass=User)(name=%(user)s))")
     AUTH_LDAP_USER_SEARCH = LDAPSearch(LDAP_USEARCH_PATH,
-                                       ldap.SCOPE_SUBTREE, "(&(objectClass=User)(name=%(user)s))")
+                                       ldap.SCOPE_SUBTREE, LDAP_SEARCH_FILTER)
     AUTH_LDAP_GROUP_SEARCH = LDAPSearch(LDAP_GSEARCH_PATH,
                                         ldap.SCOPE_SUBTREE, "(objectClass=Group)")
     AUTH_LDAP_GROUP_TYPE = ActiveDirectoryGroupType()


### PR DESCRIPTION
Allow the config to set the LDAP query filter for finding users.  This opens up a bit more configuration when dealing with other types of ldap servers.