### PR TITLE
The certificate is used to authenticate not public key

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -347,7 +347,7 @@ $ cp /srv/repo/panopuppet/config.yaml.example /srv/repo/panopuppet/config.yaml
 Use your favourite text editor to modify the file with the correct values for your envionrment.
 Please note that the example configuration file contains an example for puppetdb connection with and without SSL.
 
-Depending on your puppet infrastructure you may or may not need to specify public, private and cacert to authenticate
+Depending on your puppet infrastructure you may or may not need to specify certificate, private key and cacert files to authenticate
 with puppetdb, puppetmaster filebucket and fileserver.
 
 9) Create PanoPuppet manage.py and populate the /srv/staticfiles directory with the staticfiles.
@@ -619,7 +619,7 @@ $ cp /srv/repo/panopuppet/config.yaml.example /srv/repo/panopuppet/config.yaml
 Use your favourite text editor to modify the file with the correct values for your envionrment.
 Please note that the example configuration file contains an example for puppetdb connection with and without SSL.
 
-Depending on your puppet infrastructure you may or may not need to specify public, private and cacert to authenticate
+Depending on your puppet infrastructure you may or may not need to specify certificate, private key and cacert files to authenticate
 with puppetdb, puppetmaster filebucket and fileserver.
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,7 +10,7 @@ sources:
 # PUPPET DB CERTS - ordering is important here
 # Also, the files must be readable by the http daemon user
     'PUPPETDB_CERTIFICATES':
-      - '/path/to/public_key.pem'
+      - '/path/to/certificate.pem'
       - '/path/to/private_key.pem'
 # This setting is the default
     'PUPPETDB_VERIFY_SSL': false
@@ -20,15 +20,15 @@ sources:
     'PUPPETMASTER_CLIENTBUCKET_SHOW': true
     'PUPPETMASTER_CLIENTBUCKET_HOST': 'https://puppetmaster.example.com:8140/'
     'PUPPETMASTER_CLIENTBUCKET_CERTIFICATES':
-      - '/path/to/public.key'
-      - '/path/to/private.key'
+      - '/path/to/certificate.pem'
+      - '/path/to/private_key.pem'
     'PUPPETMASTER_CLIENTBUCKET_VERIFY_SSL': '/path/to/ca.pem'
     # Fileserver configuration for the PuppetDB Production
     'PUPPETMASTER_FILESERVER_SHOW': true
     'PUPPETMASTER_FILESERVER_HOST': 'https://puppetmaster.example.com:8140/'
     'PUPPETMASTER_FILESERVER_CERTIFICATES':
-      - '/path/to/public.key'
-      - '/path/to/private.key'
+      - '/path/to/certificate.pem'
+      - '/path/to/private_key.pem'
     'PUPPETMASTER_FILESERVER_VERIFY_SSL': '/path/to/ca.pem'
     'PUPPET_RUN_INTERVAL': 30
 


### PR DESCRIPTION
The certificate is used to authenticate not public key.
Fix configuration example and installation documentation to avoid confusion. 