### PR TITLE
Dockerfile for PanoPuppet 1.4.0 on CentOS 6 & 7.

### DIFF
--- a/docker/Docker.MD
+++ b/docker/Docker.MD
@@ -1,0 +1,67 @@
+# PanoPuppet & Docker
+
+Run PanoPuppet (non SSL configuration) in a preconfigured Docker container.
+
+
+## Files needed
+Make sure the following files are in the current directory where you build your Docker image in.
+- Dockerfile - to build the docker image
+- config.yaml - PanoPuppet config file
+- panopuppet.conf - Apache config file for PanoPuppet
+
+
+## Building the PanoPuppet Docker image
+Docker version < 1.9.0  
+If a proxy is needed, you will need to edit the Dockerfile.  
+```
+# vim Dockerfile
+<set following environment settings>
+ENV http_proxy http://proxy.company.co.uk:8080
+ENV https_proxy https://proxy.company.co.uk:8080
+
+# docker build -t panopuppet:v1.4.0  .
+```
+
+Docker version >= 1.9.0  
+--build-args can be specified for a proxy, if needed.
+```
+# docker build -t panopuppet:v1.4.0 --build-arg http_proxy=http://proxy.company.co.uk:8080 --build-arg https_proxy=https://proxy.company.co.uk:8080 .
+```
+
+Display the Docker images
+```
+# docker images
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+panopuppet          v1.4.0              df6e3453cd37        57 minutes ago      530.4 MB
+docker.io/centos    6                   6a77ab6655b9        4 weeks ago         194.6 MB
+docker.io/centos    7                   904d6c400333        4 weeks ago         196.7 MB
+```
+
+
+### Starting the PanoPuppet container
+```
+# docker run --restart=always -dt --name=panopuppet -p 90:80 panopuppet:v1.4.0
+```
+
+What this says is;
+- create a running container
+- -give it name panopuppet
+- set it to always restart, which means when the docker service starts this container will start. 
+- -p means publish a containers port; in this case the systems port 90 will be mapped to the containers port 80; replace 90 with whatever you want/is free on your host.
+
+
+### Checking status PanoPuppet container
+```
+# docker ps -a
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                NAMES
+d327335e55c9        panopuppet:v1.4.0   "apachectl -D FOREGRO"   3 seconds ago       Up 1 seconds        0.0.0.0:90->80/tcp   panopuppet
+```
+
+
+### Adding a superuser
+```
+# docker exec -it d327335e55c9 bash
+  cd /var/www/panopuppet
+  python3.5 mange.py createsuperuser
+```
+

--- a/docker/Docker.MD
+++ b/docker/Docker.MD
@@ -5,9 +5,11 @@ Run PanoPuppet (non SSL configuration) in a preconfigured Docker container.
 
 ## Files needed
 Make sure the following files are in the current directory where you build your Docker image in.
-- Dockerfile - to build the docker image
-- config.yaml - PanoPuppet config file
-- panopuppet.conf - Apache config file for PanoPuppet
+- Dockerfile      - config file to build the docker image (no need to edit)
+- panopuppet.conf - Apache config file for PanoPuppet (no need to edit)
+- manage.py       - python config file for PanoPuppet (no need to edit)
+- wsgi.py         - wsgy config file for PanoPuppet (no need to edit)
+- config.yaml     - PanoPuppet config file (provide your configuration)
 
 
 ## Building the PanoPuppet Docker image

--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -31,51 +31,17 @@ RUN yum install -y \
     curl -L https://github.com/propyless/panopuppet/archive/v1.4.0.tar.gz | tar -xzv -C /tmp  && \
     cd /tmp/panopuppet-1.4.0 && \ 
     python3.5 setup.py install
-# Copy local panopuppet.conf and config.yaml
+# Copy local config files
 # panopuppet.conf beware of Apache 2.2 settings and not 2.4
 COPY panopuppet.conf /etc/httpd/conf.d/
 COPY config.yaml /var/www/panopuppet/
-# Save on user actions for manage.py and wsgi.py, as they are custom for this container
-#COPY manage.py /var/www/panopuppet/
-#COPY wsgi.py /var/www/panopuppet/
-#
-# Perform configuration of PanoPuppet
-RUN echo $'#!/usr/bin/python3.5\n\
-import os\n\
-import sys\n\
-\n\
-os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
-\n\
-if __name__ == "__main__":\n\
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
-    from django.core.management import execute_from_command_line\n\
-    execute_from_command_line(sys.argv)'\
-> /var/www/panopuppet/manage.py && \
-    echo $'"""\n\
-WSGI config for puppet project.\n\
-It exposes the WSGI callable as a module-level variable named ``application``.\n\
-For more information on this file, see\n\
-https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/\n\
-"""\n\
-\n\
-import os\n\
-\n\
-"""\n\
-If you have another location for the config, uncomment the line below and insert a static path to the config file.\n\
-"""\n\
-os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
-\n\
-\n\
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
-from django.core.wsgi import get_wsgi_application\n\
-\n\
-application = get_wsgi_application()'\
-> /var/www/panopuppet/wsgi.py && \
-     cd /var/www/panopuppet && \
-     echo yes | python3.5 manage.py collectstatic && \
-     python3.5 manage.py makemigrations && \
-     python3.5 manage.py migrate && \
-     chown -R apache:apache /var/www/panopuppet
+COPY manage.py /var/www/panopuppet/
+COPY wsgi.py /var/www/panopuppet/
+RUN  cd /var/www/panopuppet && \
+       echo yes | python3.5 manage.py collectstatic && \
+       python3.5 manage.py makemigrations && \
+       python3.5 manage.py migrate && \
+       chown -R apache:apache /var/www/panopuppet
 # Export port 80 for Apache
 EXPOSE 80
 # Start Apache in foreground

--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -1,0 +1,82 @@
+FROM centos:6
+MAINTAINER propyless at github dot com
+#
+LABEL "com.example.vendor" = "propyless at github dot com"
+LABEL version="v1.4.0"
+LABEL description="PanoPuppet v1.4.0 on CentOS 6."
+#
+# Enable the proxy encv vars if you are behind a firewall, etc
+# or use these build-arg options when building the container;
+# docker build -t panopuppet:v1.4.0 --build-arg http_proxy=http://proxy.company.co.uk:8080 --build-arg https_proxy=https://proxy.company.co.uk:8080 .
+#ENV http_proxy http://proxy.company.co.uk:8080
+#ENV https_proxy https://proxy.company.co.uk:8080
+#
+# Install packages, download PanoPuppet and perform setup.py
+RUN yum install -y \
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm \
+      http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-11.ius.centos6.noarch.rpm && \
+    yum install -y \
+      python35u \
+      python35u-devel \
+      python35u-mod_wsgi \
+      python35u-pip \
+      httpd \
+      httpd-devel \
+      cyrus-sasl-devel \
+      gcc \
+      make \
+      openldap-devel \
+      libyaml-devel && \
+    mkdir -p /var/www/panopuppet/staticfiles && \
+    curl -L https://github.com/propyless/panopuppet/archive/v1.4.0.tar.gz | tar -xzv -C /tmp  && \
+    cd /tmp/panopuppet-1.4.0 && \ 
+    python3.5 setup.py install
+# Copy local panopuppet.conf and config.yaml
+# panopuppet.conf beware of Apache 2.2 settings and not 2.4
+COPY panopuppet.conf /etc/httpd/conf.d/
+COPY config.yaml /var/www/panopuppet/
+# Save on user actions for manage.py and wsgi.py, as they are custom for this container
+#COPY manage.py /var/www/panopuppet/
+#COPY wsgi.py /var/www/panopuppet/
+#
+# Perform configuration of PanoPuppet
+RUN echo $'#!/usr/bin/python3.5\n\
+import os\n\
+import sys\n\
+\n\
+os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
+\n\
+if __name__ == "__main__":\n\
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
+    from django.core.management import execute_from_command_line\n\
+    execute_from_command_line(sys.argv)'\
+> /var/www/panopuppet/manage.py && \
+    echo $'"""\n\
+WSGI config for puppet project.\n\
+It exposes the WSGI callable as a module-level variable named ``application``.\n\
+For more information on this file, see\n\
+https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/\n\
+"""\n\
+\n\
+import os\n\
+\n\
+"""\n\
+If you have another location for the config, uncomment the line below and insert a static path to the config file.\n\
+"""\n\
+os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
+\n\
+\n\
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
+from django.core.wsgi import get_wsgi_application\n\
+\n\
+application = get_wsgi_application()'\
+> /var/www/panopuppet/wsgi.py && \
+     cd /var/www/panopuppet && \
+     echo yes | python3.5 manage.py collectstatic && \
+     python3.5 manage.py makemigrations && \
+     python3.5 manage.py migrate && \
+     chown -R apache:apache /var/www/panopuppet
+# Export port 80 for Apache
+EXPOSE 80
+# Start Apache in foreground
+ENTRYPOINT ["apachectl", "-D", "FOREGROUND"]

--- a/docker/centos6/manage.py
+++ b/docker/centos6/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3.5
+import os
+import sys
+
+os.environ['PP_CFG'] = '/var/www/panopuppet/config.yaml'
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/docker/centos6/wsgi.py
+++ b/docker/centos6/wsgi.py
@@ -1,0 +1,19 @@
+"""
+WSGI config for puppet project.
+It exposes the WSGI callable as a module-level variable named ``application``.
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+"""
+
+import os
+
+"""
+If you have another location for the config, uncomment the line below and insert a static path to the config file.
+"""
+os.environ['PP_CFG'] = '/var/www/panopuppet/config.yaml'
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")
+from django.core.wsgi import get_wsgi_application
+
+application = get_wsgi_application()

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,0 +1,82 @@
+FROM centos:7
+MAINTAINER propyless at github dot com
+#
+LABEL "com.example.vendor" = "propyless at github dot com"
+LABEL version="v1.4.0"
+LABEL description="PanoPuppet v1.4.0 on CentOS 7."
+#
+# Enable the proxy encv vars if you are behind a firewall, etc
+# or use these build-arg options when building the container;
+# docker build -t panopuppet:v1.4.0 --build-arg http_proxy=http://proxy.company.co.uk:8080 --build-arg https_proxy=https://proxy.company.co.uk:8080 .
+#ENV http_proxy http://proxy.company.co.uk:8080
+#ENV https_proxy https://proxy.company.co.uk:8080
+#
+# Install packages, download PanoPuppet and perform setup.py
+RUN yum install -y \
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+      https://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-14.ius.centos7.noarch.rpm && \
+    yum install -y \
+      python35u \
+      python35u-devel \
+      python35u-mod_wsgi \
+      python35u-pip \
+      httpd \
+      httpd-devel \
+      cyrus-sasl-devel \
+      gcc \
+      make \
+      openldap-devel \
+      libyaml-devel && \
+    mkdir -p /var/www/panopuppet/staticfiles && \
+    curl -L https://github.com/propyless/panopuppet/archive/v1.4.0.tar.gz | tar -xzv -C /tmp  && \
+    cd /tmp/panopuppet-1.4.0 && \ 
+    python3.5 setup.py install
+# Copy local panopuppet.conf and config.yaml
+# panopuppet.conf beware of Apache 2.2 settings and not 2.4
+COPY panopuppet.conf /etc/httpd/conf.d/
+COPY config.yaml /var/www/panopuppet/
+# Save on user actions for manage.py and wsgi.py, as they are custom for this container
+#COPY manage.py /var/www/panopuppet/
+#COPY wsgi.py /var/www/panopuppet/
+#
+# Perform configuration of PanoPuppet
+RUN echo $'#!/usr/bin/python3.5\n\
+import os\n\
+import sys\n\
+\n\
+os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
+\n\
+if __name__ == "__main__":\n\
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
+    from django.core.management import execute_from_command_line\n\
+    execute_from_command_line(sys.argv)'\
+> /var/www/panopuppet/manage.py && \
+    echo $'"""\n\
+WSGI config for puppet project.\n\
+It exposes the WSGI callable as a module-level variable named ``application``.\n\
+For more information on this file, see\n\
+https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/\n\
+"""\n\
+\n\
+import os\n\
+\n\
+"""\n\
+If you have another location for the config, uncomment the line below and insert a static path to the config file.\n\
+"""\n\
+os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
+\n\
+\n\
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
+from django.core.wsgi import get_wsgi_application\n\
+\n\
+application = get_wsgi_application()'\
+> /var/www/panopuppet/wsgi.py && \
+     cd /var/www/panopuppet && \
+     echo yes | python3.5 manage.py collectstatic && \
+     python3.5 manage.py makemigrations && \
+     python3.5 manage.py migrate && \
+     chown -R apache:apache /var/www/panopuppet
+# Export port 80 for Apache
+EXPOSE 80
+# Start Apache in foreground
+ENTRYPOINT ["apachectl", "-D", "FOREGROUND"]

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -31,51 +31,17 @@ RUN yum install -y \
     curl -L https://github.com/propyless/panopuppet/archive/v1.4.0.tar.gz | tar -xzv -C /tmp  && \
     cd /tmp/panopuppet-1.4.0 && \ 
     python3.5 setup.py install
-# Copy local panopuppet.conf and config.yaml
-# panopuppet.conf beware of Apache 2.2 settings and not 2.4
+# Copy local config files
+# panopuppet.conf beware of Apache 2.4 settings and not 2.2
 COPY panopuppet.conf /etc/httpd/conf.d/
 COPY config.yaml /var/www/panopuppet/
-# Save on user actions for manage.py and wsgi.py, as they are custom for this container
-#COPY manage.py /var/www/panopuppet/
-#COPY wsgi.py /var/www/panopuppet/
-#
-# Perform configuration of PanoPuppet
-RUN echo $'#!/usr/bin/python3.5\n\
-import os\n\
-import sys\n\
-\n\
-os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
-\n\
-if __name__ == "__main__":\n\
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
-    from django.core.management import execute_from_command_line\n\
-    execute_from_command_line(sys.argv)'\
-> /var/www/panopuppet/manage.py && \
-    echo $'"""\n\
-WSGI config for puppet project.\n\
-It exposes the WSGI callable as a module-level variable named ``application``.\n\
-For more information on this file, see\n\
-https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/\n\
-"""\n\
-\n\
-import os\n\
-\n\
-"""\n\
-If you have another location for the config, uncomment the line below and insert a static path to the config file.\n\
-"""\n\
-os.environ[\'PP_CFG\'] = \'/var/www/panopuppet/config.yaml\'\n\
-\n\
-\n\
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")\n\
-from django.core.wsgi import get_wsgi_application\n\
-\n\
-application = get_wsgi_application()'\
-> /var/www/panopuppet/wsgi.py && \
-     cd /var/www/panopuppet && \
-     echo yes | python3.5 manage.py collectstatic && \
-     python3.5 manage.py makemigrations && \
-     python3.5 manage.py migrate && \
-     chown -R apache:apache /var/www/panopuppet
+COPY manage.py /var/www/panopuppet/
+COPY wsgi.py /var/www/panopuppet/
+RUN cd /var/www/panopuppet && \
+      echo yes | python3.5 manage.py collectstatic && \
+      python3.5 manage.py makemigrations && \
+      python3.5 manage.py migrate && \
+      chown -R apache:apache /var/www/panopuppet
 # Export port 80 for Apache
 EXPOSE 80
 # Start Apache in foreground

--- a/docker/centos7/manage.py
+++ b/docker/centos7/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3.5
+import os
+import sys
+
+os.environ['PP_CFG'] = '/var/www/panopuppet/config.yaml'
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/docker/centos7/wsgi.py
+++ b/docker/centos7/wsgi.py
@@ -1,0 +1,19 @@
+"""
+WSGI config for puppet project.
+It exposes the WSGI callable as a module-level variable named ``application``.
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+"""
+
+import os
+
+"""
+If you have another location for the config, uncomment the line below and insert a static path to the config file.
+"""
+os.environ['PP_CFG'] = '/var/www/panopuppet/config.yaml'
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "panopuppet.puppet.settings")
+from django.core.wsgi import get_wsgi_application
+
+application = get_wsgi_application()


### PR DESCRIPTION
Works for non SSL config of PanoPuppet.

```
docker build -t panopuppet:v1.4.0 .
docker run -dt --name=panopuppet -p 90:80 panopuppet:v1.4.0
docker exec -it <id> bash
  cd /var/www/panopuppet
  python3.5 manage.py createsuperuser
  exit
```

And thanks to @spicysomtam for the groundwork.
